### PR TITLE
Added author field required by cocoapods 1.0.0.beta.8

### DIFF
--- a/LPlaceholderTextView.podspec
+++ b/LPlaceholderTextView.podspec
@@ -1,4 +1,7 @@
 Pod::Spec.new do |s|
+  s.author = {
+  	"Luka Gabrić" => "luka.gabric@gmail.com"
+  }
   s.name         = "LPlaceholderTextView"
   s.version      = "1.0"
   s.summary      = "UITextView subclass with placeholder"


### PR DESCRIPTION
Hey i added author field based on your github profile, since if there is no author field in podspec cocoapods of version 1.0.0.beta.8 will fail telling me:
`
[!] The LPlaceholderTextView pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute authors.
`

By now i'm watching on my own fork to get this installed by cocoapods, but would be nice if you could accept this pull request so no one ever would meet this problem.
